### PR TITLE
Fixed mistype of end_datetime in booking controller

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -27,6 +27,6 @@ class BookingsController < ApplicationController
   private
 
   def booking_params
-    params.require(:booking).permit(:start_datetime, :end_datetime)
+    params.require(:booking).permit(:start_datetime, :end_date)
   end
 end


### PR DESCRIPTION
Fixed "end_datetime" typo in bookings controller