### PR TITLE
Add functionality to display all bookings after creating a new one

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -18,7 +18,7 @@ class BookingsController < ApplicationController
     @booking.status = 'pending' # Set the booking status to pending
 
     if @booking.save
-      redirect_to submarine_path(@submarine), notice: "Booking is pending approval from the owner!"
+      redirect_to bookings_path, notice: "Booking is pending approval from the owner!"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -43,9 +43,9 @@
       <%= form.datetime_select :end_date, class: 'form-control' %>
     </div>
 
-    <!-- Book Submarine Button (Link) -->
+    <!-- Submit Button -->
     <div>
-      <%= link_to 'Book Submarine', submarine_bookings_path(@submarine), class: 'btn btn-primary' %>
+      <%= form.submit 'Book Submarine', class: 'btn btn-primary' %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,17 +2,12 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "submarines#index"
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Submarines routes with nested bookings
   resources :submarines, only: [:index, :show] do
-    resources :bookings, only: [:new, :create, :index], path: "bookings"  # Nested bookings with index action
+    resources :bookings, only: [:new, :create], path: "bookings"
   end
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :bookings, only: :index
+
 end


### PR DESCRIPTION
This update allows users to view all bookings, including newly created ones, on the bookings index page. Adjusted the redirect path and ensured proper handling of POST requests to align with the desired functionality.