### PR TITLE
Filter bookings index to show only owner's submarine bookings

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -2,7 +2,7 @@ class BookingsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @bookings = Booking.includes(:user, :submarine)
+    @bookings = Booking.includes(:user, :submarine).where(submarine: { user: current_user })
   end
 
   def new


### PR DESCRIPTION
This update filters the bookings index to display only the bookings related to the current logged-in owner's submarines. It ensures that owners can view only the requests for their specific submarines in the bookings section.