### PR TITLE
Fixed destroy for all users

### DIFF
--- a/app/controllers/submarines_controller.rb
+++ b/app/controllers/submarines_controller.rb
@@ -57,8 +57,10 @@ class SubmarinesController < ApplicationController
 
     def destroy
       @submarine = Submarine.find(params[:id])
-      @submarine.destroy
-      redirect_to submarines_path, notice: 'Submarine destroyed'
+      if @submarine.user == current_user
+        @submarine.destroy
+        redirect_to submarines_path, notice: 'Submarine destroyed'
+      end
     end
 
     private

--- a/app/views/submarines/show.html.erb
+++ b/app/views/submarines/show.html.erb
@@ -47,11 +47,13 @@
     </div>
   </div>
 
+<% if @submarine.user == current_user %>
   <div class="row mt-4">
     <div class="col-md-12">
       <%= link_to 'Destroy', submarine_path(@submarine), data: { turbo_confirm: 'Are you sure you want to delete this submarine?', turbo_method: :delete }, class: 'btn btn-danger' %>
     </div>
   </div>
+<% end %>
 
   <div class="row mt-4">
     <div class="col-md-12">


### PR DESCRIPTION
Fixed the issue where all users could delete submarines.
Not logged in - Cant delete anything.
Owner of the submarine - Can delete submarine.
Logged in but as different user - Cant delete anything.
![Screenshot 2025-01-30 234958](https://github.com/user-attachments/assets/eb2a2dae-4a2f-4b95-9e23-b7180255f614)
![Screenshot 2025-01-30 235017](https://github.com/user-attachments/assets/0cab3a4b-284f-4cc8-a68e-3de8272d05fc)
